### PR TITLE
Update gdata gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,12 +2,12 @@
 source "http://rubygems.org"
 
 gem "rake"
-gem 'gdata', :require => false
-gem 'hpricot'
-gem 'nokogiri'
-gem "multi_json", '~>1.10', '>= 1.10.1'
-gem 'test-unit'
+gem "gdata", "1.1.2", :require => false
+gem "hpricot"
+gem "nokogiri"
+gem "multi_json", "~>1.10", ">= 1.10.1"
+gem "test-unit"
 
 group :test do
-  gem 'shoulda'
+  gem "shoulda"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 source "http://rubygems.org"
 
 gem "rake"
-gem 'gdata19', :git => 'git://github.com/paperlesspost/gdata.git'
+gem 'gdata', :require => false
 gem 'hpricot'
 gem 'nokogiri'
 gem "multi_json", '~>1.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,7 @@
-GIT
-  remote: git://github.com/paperlesspost/gdata.git
-  revision: 91f3a5b2e701c879ae5dfcb48dec5bb039e37a7b
-  specs:
-    gdata19 (0.1.9.2)
-
 GEM
   remote: http://rubygems.org/
   specs:
+    gdata (1.1.2)
     hpricot (0.8.4)
     multi_json (1.3.7)
     nokogiri (1.5.2)
@@ -18,7 +13,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  gdata19!
+  gdata
   hpricot
   multi_json (~> 1.3)
   nokogiri

--- a/Rakefile
+++ b/Rakefile
@@ -1,23 +1,16 @@
-require 'rubygems'
-require 'rake'
-require './lib/contacts'
+require "rake"
+require "rake/testtask"
 
-desc "Default Task"
-task :default => [ :test ]
-
-# Run the unit tests
-desc "Run all unit tests"
-require 'rake/testtask'
-Rake::TestTask.new(:test) do |test|
-  test.libs << 'lib' << 'test'
-  test.pattern = 'test/**/test_*.rb'
-  test.verbose = true
+Rake::TestTask.new(:test) do |t|
+  t.libs << 'lib' << 'test'
+  t.pattern = 'test/**/test_*.rb'
+  t.verbose = true
 end
 
+task :default => [:test]
 
 # Make a console, useful when working on tests
 desc "Generate a test console"
 task :console do
    verbose( false ) { sh "irb -I lib/ -r 'contacts'" }
 end
-

--- a/contacts.gemspec
+++ b/contacts.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "contacts"
-  s.version = "1.5.9.paperlesspost"
+  s.version = "1.5.10.paperlesspost"
   s.date = "2013-01-10"
   s.summary = "A universal interface to grab contact list information from various providers including Outlook, Address Book, Yahoo, AOL, Gmail, Hotmail, and Plaxo."
   s.homepage = "http://github.com/paperlesspost/contacts"

--- a/contacts.gemspec
+++ b/contacts.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.authors = ["Lucas Carlson", "Paperless Post"]
   s.files = `git ls-files`.split($\)
   s.add_dependency("multi_json", '~>1.10', '>= 1.10.1')
-  s.add_dependency('gdata', '1.1.1.paperlesspost')
+  s.add_dependency('gdata', '1.1.2')
   s.add_dependency('hpricot')
   s.add_dependency('nokogiri')
   s.add_dependency('encryptor')

--- a/lib/contacts.rb
+++ b/lib/contacts.rb
@@ -1,11 +1,13 @@
-$:.unshift(File.dirname(__FILE__)+"/contacts/")
 
-require 'json_picker'
-require 'base'
-require 'gmail'
-require 'hotmail'
-require 'yahoo'
-require 'plaxo'
-require 'vcf'
-require 'outlook'
-require 'aol_importer'
+# modules
+require 'contacts/json_picker'
+require 'contacts/base'
+
+# classes
+require 'contacts/aol_importer'
+require 'contacts/gmail'
+require 'contacts/hotmail'
+require 'contacts/outlook'
+require 'contacts/plaxo'
+require 'contacts/vcf'
+require 'contacts/yahoo'

--- a/lib/contacts.rb
+++ b/lib/contacts.rb
@@ -1,3 +1,8 @@
+# libs
+# This is a patch that loads the stock gdata gem without the outdated jcode dependency
+require 'gdata/http'
+require 'gdata/client'
+require 'gdata/auth'
 
 # modules
 require 'contacts/json_picker'

--- a/lib/contacts.rb
+++ b/lib/contacts.rb
@@ -1,8 +1,3 @@
-# libs
-# This is a patch that loads the stock gdata gem without the outdated jcode dependency
-require 'gdata/http'
-require 'gdata/client'
-require 'gdata/auth'
 
 # modules
 require 'contacts/json_picker'

--- a/lib/contacts/gmail.rb
+++ b/lib/contacts/gmail.rb
@@ -1,21 +1,24 @@
-require 'gdata'
+# This is a patch that loads the stock gdata gem without the outdated jcode dependency
+require 'gdata/http'
+require 'gdata/client'
+require 'gdata/auth'
 
 class Contacts
   class Gmail < Base
-    
+
     CONTACTS_SCOPE = 'http://www.google.com/m8/feeds/'
     CONTACTS_FEED = CONTACTS_SCOPE + 'contacts/default/full/?max-results=1000'
-    
+
     def contacts
       return @contacts if @contacts
     end
-    
+
     def real_connect
       @client = GData::Client::Contacts.new
       @client.clientlogin(@login, @password, @captcha_token, @captcha_response)
-      
+
       feed = @client.get(CONTACTS_FEED).to_xml
-      
+
       @contacts = feed.elements.to_a('entry').collect do |entry|
         title, email = entry.elements['title'].text, nil
         entry.elements.each('gd:email') do |e|


### PR DESCRIPTION
Story: https://www.pivotaltracker.com/n/projects/1106466/stories/84862982

Updates the [gdata](http://rubygems.org/gems/gdata) gem to the newer stock version (1.1.2)

Patches the require (see gmail.rb) to not include the outdated jcode gem dependency.  This (please confirm) is the only change from our custom gem that is not in trunk at this point

cc @quirkey @GordonDiggs 
